### PR TITLE
prevent ProgressBar from allowing values greater than 100

### DIFF
--- a/src/components/ProgressBar/ProgressBar.js
+++ b/src/components/ProgressBar/ProgressBar.js
@@ -30,7 +30,7 @@ const ProgressBar = ({ small = false, progress }) => {
   const progressBarSizeStyle = small ? styles.progressBarBoxSmall : styles.progressBarBoxRegular;
 
   const widthStyle = {
-    width: `${progress}%`,
+    width: `${Math.min(progress, 100)}%`,
   };
 
   let progressBar = null;


### PR DESCRIPTION
This prevents ProgressBar from overflowing its container where consumers pass values greater than 100%.